### PR TITLE
Stable sorting for Markdown and HTML output. Add a minimal test.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,18 +22,20 @@ homepage := Some(url("https://github.com/balhoff/owl-diff"))
 
 scalaVersion  := "2.13.15"
 
-crossScalaVersions := Seq("2.11.12", "2.12.20", "2.13.15")
+crossScalaVersions := Seq("2.12.20", "2.13.15")
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
-scalacOptions in Test ++= Seq("-Yrangepos")
+Test / scalacOptions ++= Seq("-Yrangepos")
 
-fork in Test := true
+testFrameworks += new TestFramework("utest.runner.Framework")
 
 libraryDependencies ++= {
   Seq(
     "net.sourceforge.owlapi" %  "owlapi-distribution" % "4.5.29",
-    "org.apache.commons"     %  "commons-text"        % "1.12.0"
+    "org.apache.commons"     %  "commons-text"        % "1.12.0",
+    "com.lihaoyi"            %% "utest"               % "0.8.3"  % Test,
+    "com.outr"               %% "scribe-slf4j2"       % "3.15.2" % Test
   )
 }
 

--- a/src/main/scala/org/geneontology/owl/differ/Differ.scala
+++ b/src/main/scala/org/geneontology/owl/differ/Differ.scala
@@ -32,7 +32,7 @@ object Differ {
 
   }
 
-  final case class ModifiedAnnotation(item: OWLAnnotation, added: Boolean) extends ModifiedOntologyContent[OWLAnnotation] {
+  final case class ModifiedOntologyAnnotation(item: OWLAnnotation, added: Boolean) extends ModifiedOntologyContent[OWLAnnotation] {
 
     def owlObject: OWLObject = item
 
@@ -73,9 +73,9 @@ object Differ {
   def groupedDiff(diff: BasicDiff): GroupedDiff = {
     val allChangedAxioms: Set[ModifiedOntologyContent[_]] = diff.left.axioms.map(ModifiedAxiom(_, false)) ++ diff.right.axioms.map(ModifiedAxiom(_, true))
     val allChangedImports: Set[ModifiedOntologyContent[_]] = diff.left.imports.map(ModifiedImport(_, false)) ++ diff.right.imports.map(ModifiedImport(_, true))
-    val allChangedAnnotations: Set[ModifiedOntologyContent[_]] = diff.left.annotations.map(ModifiedAnnotation(_, false)) ++ diff.right.annotations.map(ModifiedAnnotation(_, true))
+    val allChangedAnnotations: Set[ModifiedOntologyContent[_]] = diff.left.annotations.map(ModifiedOntologyAnnotation(_, false)) ++ diff.right.annotations.map(ModifiedOntologyAnnotation(_, true))
     val groupedAxioms = allChangedAxioms.groupBy {
-      case ModifiedAxiom(ax, _)     =>
+      case ModifiedAxiom(ax, _)             =>
         AxiomSubjectProviderInst.getSubject(ax) match {
           case named: OWLNamedObject => IRIGrouping(named.getIRI)
           case iri: IRI              => IRIGrouping(iri)
@@ -83,8 +83,8 @@ object Differ {
           case _: SWRLObject         => RuleGrouping
           case subj                  => NonIRIGrouping(subj)
         }
-      case ModifiedAnnotation(_, _) => OntologyAnnotationGrouping //shouldn't be matched
-      case ModifiedImport(_, _)     => OntologyImportGrouping //shouldn't be matched
+      case ModifiedOntologyAnnotation(_, _) => OntologyAnnotationGrouping //shouldn't be matched
+      case ModifiedImport(_, _)             => OntologyImportGrouping //shouldn't be matched
     }
     val allGrouped = groupedAxioms + (OntologyImportGrouping -> allChangedImports) + (OntologyAnnotationGrouping -> allChangedAnnotations)
     GroupedDiff(diff.left.id, diff.left.source, diff.right.id, diff.right.source, allGrouped)

--- a/src/main/scala/org/geneontology/owl/differ/render/HTMLDiffRenderer.scala
+++ b/src/main/scala/org/geneontology/owl/differ/render/HTMLDiffRenderer.scala
@@ -69,9 +69,12 @@ object HTMLDiffRenderer {
       group <- sortedGroups
     } yield {
       def sortKey(modifiedItem: ModifiedOntologyContent[_]): String = modifiedItem match {
-        case ModifiedAnnotation(item, _) => item.toString
-        case ModifiedImport(item, _)     => item.toString
-        case ModifiedAxiom(item, _)      => item.getAxiomType.getName
+        case ModifiedOntologyAnnotation(item, _) => item.toString
+        case ModifiedImport(item, _)             => item.toString
+        case ModifiedAxiom(item, _)      => item.getAxiomType match {
+          case AxiomType.DECLARATION => s"1-${item.toString}"
+          case _                     => s"2-${item.toString}"
+        }
       }
 
       val removed = diff.groups(group).filterNot(_.added).toSeq.sortBy(sortKey)

--- a/src/main/scala/org/geneontology/owl/differ/render/MarkdownGroupedDiffRenderer.scala
+++ b/src/main/scala/org/geneontology/owl/differ/render/MarkdownGroupedDiffRenderer.scala
@@ -37,10 +37,15 @@ object MarkdownGroupedDiffRenderer {
     val content = (for {
       group <- sortedGroups
     } yield {
-      def sortKey(modifiedItem: ModifiedOntologyContent[_]): String = modifiedItem match {
-        case ModifiedAnnotation(item, _) => item.toString
-        case ModifiedImport(item, _)     => item.toString
-        case ModifiedAxiom(item, _)      => item.getAxiomType.getName
+      def sortKey(modifiedItem: ModifiedOntologyContent[_]): String = {
+        modifiedItem match {
+          case ModifiedOntologyAnnotation(item, _) => item.toString
+          case ModifiedImport(item, _)             => item.toString
+          case ModifiedAxiom(item, _)      => item.getAxiomType match {
+            case AxiomType.DECLARATION => s"1-${item.toString}"
+            case _                     => s"2-${item.toString}"
+          }
+        }
       }
 
       val removed = diff.groups(group).filterNot(_.added).toSeq.sortBy(sortKey)

--- a/src/test/resources/left-1.ofn
+++ b/src/test/resources/left-1.ofn
@@ -1,0 +1,51 @@
+Prefix(:=<http://example.org//>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://example.org/>
+
+Declaration(Class(<http://example.org/A>))
+Declaration(Class(<http://example.org/B>))
+Declaration(Class(<http://example.org/C>))
+Declaration(Class(<http://example.org/D>))
+Declaration(AnnotationProperty(<http://example.org/1>))
+############################
+#   Annotation Properties
+############################
+
+# Annotation Property: <http://example.org/1> (definition)
+
+AnnotationAssertion(rdfs:label <http://example.org/1> "definition")
+
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://example.org/A> (class one)
+
+AnnotationAssertion(<http://example.org/1> <http://example.org/A> "Definition one.")
+AnnotationAssertion(rdfs:label <http://example.org/A> "class one")
+SubClassOf(<http://example.org/A> <http://example.org/B>)
+
+# Class: <http://example.org/B> (class two)
+
+AnnotationAssertion(<http://example.org/1> <http://example.org/B> "Definition two.")
+AnnotationAssertion(rdfs:label <http://example.org/B> "class two")
+
+# Class: <http://example.org/C> (class three)
+
+AnnotationAssertion(rdfs:label <http://example.org/C> "class three")
+EquivalentClasses(<http://example.org/C> <http://example.org/D>)
+
+# Class: <http://example.org/D> (class four)
+
+AnnotationAssertion(rdfs:label <http://example.org/D> "class four")
+
+
+)

--- a/src/test/resources/right-1.ofn
+++ b/src/test/resources/right-1.ofn
@@ -1,0 +1,59 @@
+Prefix(:=<http://example.org//>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://example.org/>
+
+Declaration(Class(<http://example.org/A>))
+Declaration(Class(<http://example.org/B>))
+Declaration(Class(<http://example.org/C>))
+Declaration(Class(<http://example.org/D>))
+Declaration(Class(<http://example.org/E>))
+Declaration(AnnotationProperty(<http://example.org/1>))
+############################
+#   Annotation Properties
+############################
+
+# Annotation Property: <http://example.org/1> (definition)
+
+AnnotationAssertion(rdfs:label <http://example.org/1> "definition")
+
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://example.org/A> (class five-one)
+
+AnnotationAssertion(<http://example.org/1> <http://example.org/A> "Definition one-five.")
+AnnotationAssertion(rdfs:label <http://example.org/A> "class five-one")
+EquivalentClasses(<http://example.org/A> <http://example.org/E>)
+SubClassOf(<http://example.org/A> <http://example.org/C>)
+
+# Class: <http://example.org/B> (class two)
+
+AnnotationAssertion(<http://example.org/1> <http://example.org/B> "Definition two.")
+AnnotationAssertion(rdfs:label <http://example.org/B> "class two")
+
+# Class: <http://example.org/C> (class three)
+
+AnnotationAssertion(rdfs:label <http://example.org/C> "class three")
+EquivalentClasses(<http://example.org/C> <http://example.org/D>)
+
+# Class: <http://example.org/D> (class four)
+
+AnnotationAssertion(rdfs:label <http://example.org/D> "class four")
+
+# Class: <http://example.org/E> (class five)
+
+AnnotationAssertion(<http://example.org/1> <http://example.org/E> "Definition a.")
+AnnotationAssertion(<http://example.org/1> <http://example.org/E> "Definition five.")
+AnnotationAssertion(rdfs:label <http://example.org/E> "class five")
+
+
+)

--- a/src/test/scala/org/geneontology/owl/differ/TestMarkdownSorting.scala
+++ b/src/test/scala/org/geneontology/owl/differ/TestMarkdownSorting.scala
@@ -1,0 +1,29 @@
+package org.geneontology.owl.differ
+
+import org.geneontology.owl.differ.render.MarkdownGroupedDiffRenderer
+import org.semanticweb.owlapi.apibinding.OWLManager
+import utest._
+
+import java.io.File
+
+object TestMarkdownSorting extends TestSuite {
+
+  val tests: Tests = Tests {
+    val left = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new File("src/test/resources/left-1.ofn"))
+    val right = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new File("src/test/resources/right-1.ofn"))
+    test("Things are ordered") {
+      val diff = Differ.diff(left, right)
+      val grouped = Differ.groupedDiff(diff)
+      val output = MarkdownGroupedDiffRenderer.render(grouped, right.getOWLOntologyManager)
+      assert(output.indexOf("Class: [class five](http://example.org/E)") <
+        output.indexOf("[class five](http://example.org/E) [label](http://www.w3.org/2000/01/rdf-schema#label) \"class five\""))
+      assert(output.indexOf("[class five-one](http://example.org/A) [label](http://www.w3.org/2000/01/rdf-schema#label) \"class five-one\"") >
+        output.indexOf("[class five-one](http://example.org/A) [definition](http://example.org/1) \"Definition one-five.\""))
+      assert(output.indexOf("[class five-one](http://example.org/A) EquivalentTo [class five](http://example.org/E)") >
+        output.indexOf("[class five-one](http://example.org/A) [label](http://www.w3.org/2000/01/rdf-schema#label) \"class five-one\""))
+      assert(output.indexOf("[class five-one](http://example.org/A) SubClassOf [class three](http://example.org/C)") >
+        output.indexOf("[class five-one](http://example.org/A) EquivalentTo [class five](http://example.org/E)"))
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #82. The previous sorting code only sorted axioms in each group by the name of the axiom type, rather than by the axiom content.